### PR TITLE
Add placeholder attribute to search form

### DIFF
--- a/core/c/typesearch.php
+++ b/core/c/typesearch.php
@@ -13,7 +13,8 @@ class TypeSearch extends FormAttributes implements IForm
 {
     private $_attributes = array(
         self::FORM_ATTRIBUTE_CLASS  => '',
-        self::FORM_ATTRIBUTE_ID     => ''
+        self::FORM_ATTRIBUTE_ID     => '',
+        self::FORM_ATTRIBUTE_PLACEHOLDER    => ''
     );
 
     public function loadElement( $attributes )
@@ -29,7 +30,7 @@ class TypeSearch extends FormAttributes implements IForm
      */
     private function _setElement( )
     {
-        $this->_element = '<input type="search" ID CLASS>' . "\n";
+        $this->_element = '<input type="search" placeholder="PLACEHOLDER" ID CLASS>' . "\n";
     }
 
 


### PR DESCRIPTION
A placeholder attribute has been added to the input type search in typesearch.php. This attribute allows a short hint, a word or a short phrase, to be displayed in the input field before the user enters a value. The change was made to enhance the user experience by providing contextual help in the search field.