### PR TITLE
Changed Class reference and renamed Module.php file

### DIFF
--- a/core/c/module.php
+++ b/core/c/module.php
@@ -30,7 +30,7 @@ class Module extends Adapter\Module
     protected function _set(string $name, $value): void
     {
         try {
-            $_class_properties = get_class_vars(__CLASS__);
+            $_class_properties = get_class_vars(get_called_class());
             if (array_key_exists($name, $_class_properties))
             {
                 $this->$name = $value;
@@ -49,7 +49,7 @@ class Module extends Adapter\Module
     protected function _get(string $name): mixed
     {
         try {
-            $_class_properties = get_class_vars(__CLASS__);
+            $_class_properties = get_class_vars(get_called_class());
             if (array_key_exists($name, $_class_properties))
             {
                 return $this->$name;


### PR DESCRIPTION
The name of 'Module.php' file in 'core/c' directory has been renamed to lowercase 'module.php', ensuring consistency across all filenames. The code inside the file has been updated, replacing '__CLASS__' with 'get_called_class()', allowing the correct class scope to be referenced even in an inherited context and ensuring proper function of '_set' and '_get' methods.